### PR TITLE
Refactor Archetype class and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,47 @@ Node 12.x.x+
 # Usage
 
 
-The library needs to be configured with your account's **app_id** and **secret key** which is available in your **[Archetype Dashboard](app.archetype.dev/settings)**. Set `archetype.app_id` and `archetype.secret_key` to their values:
+The library needs to be configured with your account's `app_id` and `secret_key` which are available in your **[Archetype Dashboard](app.archetype.dev/settings)**. 
+
+You can set them up through your environment variables as shown below:
+
+```sh
+export ARCHETYPE_APP_ID=your_app_id
+export ARCHETYPE_SECRET_KEY=your_secret_key
+```
+
+When you're ready to start using the SDK, initialize it as shown below:
+
+```js
+const { Archetype } = require("@archetypeapi/node");
+
+const ArchetypeSDK = new Archetype();
+```
+
+OR
+
+You can also initialize the SDK with your `app_id` and `secret_key` directly:
+
+```js
+const { Archetype } = require("@archetypeapi/node");
+
+const appId = 'your_app_id'; // find in your Archetype Dashboard
+const appSecret = 'your_secret_key'; // find in your Archetype Dashboard
+
+const ArchetypeSDK = new Archetype(appId, appSecret);
+```
+
+The SDK can be used to create and configure billable metrics, products, token management, authorization and more. Check out [the docs](https://docs.archetype.dev/docs/welcome) for more examples and use cases.
 
 ```js
 const express = require("express");
 const router = express.Router();
-const { ArchetypeApi } = require("@archetypeapi/node");
+const ArchetypeApi = require("@archetypeapi/node");
 
-const appId = process.env.APP_ID; // find in your Archetype Dashboard
-const secretKey = process.env.SECRET_KEY; // find in your Archetype Dashboard
+const appId = process.env.ARCHETYPE_APP_ID; // find in your Archetype Dashboard
+const secretKey = process.env.ARCHETYPE_SECRET_KEY; // find in your Archetype Dashboard
 
-const Archetype = ArchetypeApi(appId, appSecret);
+const Archetype = new ArchetypeApi.Archetype(appId, appSecret);
 
 
 // BASIC FUNCTIONS
@@ -99,25 +129,25 @@ const checkoutSession = Archetype.customer.CreateCheckoutSession(customUid: stri
 const key = Archetype.customer.ResetAPIKey(customUid: string, apikey: string, version: number);
 
 // create sandbox subscription
-const subscription = CreateSandboxSubscription(customUid: string, productId: string, sandboxDuration: string, version: number);
+const subscription = Archetype.customer.CreateSandboxSubscription(customUid: string, productId: string, sandboxDuration: string, version: number);
 
 // cancel subscription
-const canceledSub = CancelSubscription(customUid: string, version: number = 1, params: any = {});
+const canceledSub = Archetype.customer.CancelSubscription(customUid: string, version: number = 1, params: any = {});
 
 // create checkout session
-const checkoutSession = archetype.customer.CreateCheckoutSession("CUSTOM_UID", "PRODUCT_ID");
+const checkoutSession = Archetype.customer.CreateCheckoutSession("CUSTOM_UID", "PRODUCT_ID");
 
 // update customer
-const updatedCustomer = archetype.customer.update("CUSTOM_UID", params); // example params: {email: "asdf@archetype.dev"}
+const updatedCustomer = Archetype.customer.update("CUSTOM_UID", params); // example params: {email: "asdf@archetype.dev"}
 
 // list billable metrics
-const billableMetrics = archetype.billableMetric.all();
+const billableMetrics = Archetype.billableMetric.all();
 
 // retrieve billable metric
-const billableMetric = archetype.billableMetric.retrieve("BILLABLE_METRIC_ID");
+const billableMetric = Archetype.billableMetric.retrieve("BILLABLE_METRIC_ID");
 
 // create billable metric
-const billableMetric = archetype.billableMetric.create({
+const billableMetric = Archetype.billableMetric.create({
                           name: "Storage",
                           description: "test",
                           unit: "GB",
@@ -132,17 +162,24 @@ Archetype.billableMetric.logUsage(
 );
 
 // get user token
-const token = archetype.token.get("CUSTOM_UID");
+const token = Archetype.token.get("CUSTOM_UID");
 
+```
+
+# Middleware
+
+The SDK can also be used as middleware in Express applications to authorize requests. 
+
+```js
 // Authorize an Express Request with Archetype Middelware
 const express = require('express');
-const { Auth } = require('@archetypeapi/node');
+const { AuthMiddleware } = require('@archetypeapi/node');
 const app = express();
 
-const appId = process.env.APP_ID; // find in your Archetype Dashboard
-const secretKey = process.env.SECRET_KEY; // find in your Archetype Dashboard
+const appId = process.env.ARCHETYPE_APP_ID; // find in your Archetype Dashboard
+const secretKey = process.env.ARCHETYPE_SECRET_KEY; // find in your Archetype Dashboard
 
-const ArchetypeAuth = Auth(appId, appSecret);
+const ArchetypeAuth = AuthMiddleware(appId, appSecret);
 
 app.get('/a', ArchetypeAuth, (req, res) => {
   res.send('Success!')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,29 @@
 {
   "name": "@archetypeapi/node",
-  "version": "0.0.1",
+  "version": "1.0.74",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@archetypeapi/node",
-      "version": "0.0.1",
+      "version": "1.0.74",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",
         "express": "^4.17.1"
       },
       "devDependencies": {
+        "@types/node": "^20.11.30",
         "typescript": "^4.5.4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/accepts": {
@@ -664,6 +674,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -690,6 +706,15 @@
     }
   },
   "dependencies": {
+    "@types/node": {
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1157,6 +1182,12 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,5 @@
     "@types/node": "^20.11.30",
     "typescript": "^4.5.4"
   },
-  "version": "1.0.74"
+  "version": "1.0.75"
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express": "^4.17.1"
   },
   "devDependencies": {
+    "@types/node": "^20.11.30",
     "typescript": "^4.5.4"
   },
   "version": "1.0.74"

--- a/src/ApiRequestor.ts
+++ b/src/ApiRequestor.ts
@@ -1,7 +1,6 @@
+import {Method} from "./utils";
+import axios from 'axios';
 
-
-import { Method } from "./utils";
-import axios, { AxiosResponse } from 'axios';
 const constants =  require("./constants");
 const HttpClient = require("./HttpClient");
 
@@ -65,11 +64,11 @@ class ApiRequestorV2 {
   private readonly secretKey: string;
   private _httpClient: any;
   private readonly _baseUrl: string;
-  constructor(appId?: string, secretKey?: string) {
+  constructor(appId?: string, secretKey?: string, baseUrl?: string) {
     this.appId = appId || constants.appId;
     this.secretKey = secretKey || constants.secretKey;
     this._httpClient = new HttpClient();
-    this._baseUrl = constants.apiBaseUrl;
+    this._baseUrl = baseUrl || constants.apiBaseUrl;
   }
 
   _buildUrl(path: string) {
@@ -77,13 +76,12 @@ class ApiRequestorV2 {
   }
 
   _buildHeaders() {
-    const requestHeaders = {
+    return {
       'Authorization': `Bearer ${this.secretKey}`,
       'X-Archetype-AppID': this.appId,
       'X-Archetype-SecretKey': this.secretKey,
       'X-Archetype-LiveMode': `${this.secretKey.includes('_sk_prod_')}`,
     };
-    return requestHeaders;
   }
 
   _buildParams(params: object) {
@@ -93,8 +91,7 @@ class ApiRequestorV2 {
   async request(method: string, path: string, body?: object, params?: object, headers?: object) {
     const url = this._buildUrl(path);
     const requestHeaders = this._buildHeaders();
-    const requestParams = params;
-    return this._httpClient.makeRequest(method, url, body, requestParams, requestHeaders);
+    return this._httpClient.makeRequest(method, url, body, params, requestHeaders);
   }
 }
 

--- a/src/Archetype.ts
+++ b/src/Archetype.ts
@@ -4,12 +4,14 @@ import { Endpoint } from "./resources/endpoint";
 import { Product } from "./resources/product";
 import { Token } from "./resources/token";
 
+const constants =  require("./constants");
+
 //import { RetrievableAPIResource } from "./resources/resource";
 class Archetype {
     private static instance: Archetype;
-    private appId: string;
-    private secretKey: string;
-    private baseUrl = "https://api.archetype.dev";
+    private readonly appId: string;
+    private readonly secretKey: string;
+    private readonly baseUrl: string = "https://api.archetype.dev";
     public customer: Customer;
     public endpoint: Endpoint;
     public product: Product;
@@ -17,27 +19,31 @@ class Archetype {
     public token: Token;
 
 
-    constructor(appId: string, secretKey: string, baseUrl?: string) {
-      this.appId = appId;
-      this.secretKey = secretKey;
-      this.baseUrl = baseUrl || this.baseUrl
-      this.endpoint = new Endpoint(appId, secretKey, this.baseUrl)
-      this.product = new Product(appId, secretKey, this.baseUrl)
-      this.billableMetric = new BillableMetric(appId, secretKey, this.baseUrl)
-      this.token = new Token(appId, secretKey, this.baseUrl)
-      this.customer = new Customer(appId, secretKey, this.baseUrl)
+    constructor(appId?: string , secretKey?: string, baseUrl?: string) {
+      this.appId = appId || constants.appId;
+      this.secretKey = secretKey || constants.secretKey;
+      this.baseUrl = baseUrl || constants.apiBaseUrl;
+      this.endpoint = new Endpoint(this.appId, this.secretKey, this.baseUrl)
+      this.product = new Product(this.appId, this.secretKey, this.baseUrl)
+      this.billableMetric = new BillableMetric(this.appId, this.secretKey, this.baseUrl)
+      this.token = new Token(this.appId, this.secretKey, this.baseUrl)
+      this.customer = new Customer(this.appId, this.secretKey, this.baseUrl)
+
+      if (!this.appId || !this.secretKey) {
+        throw new Error('App ID and Secret Key must be provided');
+      }
     }
 
-    public static getArchetypeInstance(appId?: string, secretKey?: string): Archetype {
+    public static getArchetypeInstance(appId?: string, secretKey?: string, baseUrl?: string): Archetype {
         if (!Archetype.instance) {
             if (!appId || !secretKey) {
                 throw new Error('App ID and Secret Key must be provided');
               }
-            Archetype.instance = new Archetype(appId, secretKey);
+            Archetype.instance = new Archetype(appId, secretKey, baseUrl);
         }
         return Archetype.instance;
       }
-    
+
       public getAppId(): string {
         return this.appId;
       }
@@ -45,9 +51,8 @@ class Archetype {
       public getSecretKey(): string {
         return this.secretKey;
       }
-  
+
   }
 
 
 export { Archetype };
-  

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
-const appId = process.env.APP_ID
-const secretKey = process.env.SECRET_KEY
-const apiBaseUrl = process.env.API_BASE_URL || "https://api.archetype.dev";
+const appId = process.env.ARCHETYPE_APP_ID
+const secretKey = process.env.ARCHETYPE_SECRET_KEY
+const apiBaseUrl = process.env.ARCHETYPE_API_BASE_URL || "https://api.archetype.dev";
 const uploadApiBase = "https://files.archetype.dev";
 const authVersion = 4;
 

--- a/src/resources/customer.ts
+++ b/src/resources/customer.ts
@@ -1,8 +1,3 @@
-/*import { RetrievableAPIResource, ListableAPIResource } from './resource';
-import { Method } from '../utils';
-import { APIRequest } from '../ApiRequestor';
-*/
-//const {ApiResource} = require("./resource");
 import { ApiResource } from "./resource";
 
 export class Customer extends ApiResource {
@@ -17,7 +12,7 @@ export class Customer extends ApiResource {
         email: email,
         name: name
       };
-  
+
       return super.create(params, 2);
     }
 
@@ -35,7 +30,7 @@ export class Customer extends ApiResource {
         }
         return this._requestor.request('POST', path, params);
       }
-    
+
       async CreateSandboxSubscription(customUid: string, productId: string, sandboxDuration: string, version?: number, ) {
         const resolvedVersion = version !== undefined ? version : 1;
         const path = `/api/v${resolvedVersion}/${this._objectName}/${customUid}/create-promo/${productId}`;
@@ -44,7 +39,7 @@ export class Customer extends ApiResource {
         }
         return this._requestor.request('POST', path, params);
       }
-    
+
       async CancelSubscription(customUid: string, version?: number, params: any = {}) {
         const resolvedVersion = version !== undefined ? version : 1;
         const path = `/api/v${resolvedVersion}/${this._objectName}/${customUid}/cancel-subscription`;
@@ -54,7 +49,7 @@ export class Customer extends ApiResource {
       static Usage(): void {
         // Method implementation
       }
-    
+
       static Invoices(): void {
         // Method implementation
       }

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -1,18 +1,15 @@
-import { APIRequest } from '../ApiRequestor';
 import { ApiRequestorV2 } from '../ApiRequestor';
-
-import { Method } from '../utils';
 
 interface APIResource {
   [key: string]: any;
-}  
+}
 
   export class ApiResource {
     public _requestor: ApiRequestorV2;
     public readonly _objectName: string;
 
     constructor(objectName: string, appId?: string, secretKey?: string, baseUrl?: string) {
-      this._requestor = new ApiRequestorV2(appId, secretKey);
+      this._requestor = new ApiRequestorV2(appId, secretKey, baseUrl);
       this._objectName = objectName;
     }
 
@@ -21,25 +18,25 @@ interface APIResource {
         const path = `/api/v${resolvedVersion}/${this._objectName}/${id}`;
         return this._requestor.request('GET', path);
       }
-    
+
     async all(version?: number) {
         const resolvedVersion = version !== undefined ? version : 1;
         const path = `/api/v${resolvedVersion}/${this._objectName}s`;
         return this._requestor.request('GET', path);
     }
-    
+
     async create(params: any, version?: number) {
       const resolvedVersion = version !== undefined ? version : 1;
       const path = `/api/v${resolvedVersion}/create-${this._objectName}`
       return this._requestor.request('POST', path, params);
     }
-  
+
     async update(id: string, body: any = {}, version?: number, params?: any) {
       const resolvedVersion = version !== undefined ? version : 1;
       const path = `/api/v${resolvedVersion}/${this._objectName}/${id}`;
       return this._requestor.request('PUT', path, body, params);
     }
-  
+
     async delete(id: string, version?: number, params?: any) {
       const resolvedVersion = version !== undefined ? version : 1;
       const path = `/api/v${resolvedVersion}/${this._objectName}/${id}`;

--- a/src/resources/token.ts
+++ b/src/resources/token.ts
@@ -4,12 +4,6 @@ export class Token extends ApiResource {
     constructor(appId?: string, secretKey?: string, baseUrl?: string) {
         super("token", appId, secretKey, baseUrl);
       }
-    
-      /*
-      async create(params: any, version?: number) {
-        return super.create(version, params);
-      }
-      */
 
       async get(customUid: string, version: number = 1) {
         const path = `/customer-portal/tokens/v1/create`;


### PR DESCRIPTION
Refactored the Archetype class to allow for optionality in initialisation parameters - app ID, secret key, base URL - falling back to constants if not provided. It throws an error if app ID and secret key are not specified. Furthermore, updated the README.md to reflect these changes, and also improved instructions for SDK set up and use. Scattered clean-ups around the codebase for better readability and efficiency, including removing some commented-out code and unnecessary variables.